### PR TITLE
Path param maps

### DIFF
--- a/lib/maverick/api/initializer.ex
+++ b/lib/maverick/api/initializer.ex
@@ -61,7 +61,6 @@ defmodule Maverick.Api.Initializer do
         end
       end
 
-    Macro.to_string(contents) |> IO.puts()
     quote bind_quoted: [contents: contents], do: contents
   end
 
@@ -99,14 +98,17 @@ defmodule Maverick.Api.Initializer do
   end
 
   defp path_var_map(path) do
-    Enum.reduce(path, %{}, fn element, acc ->
-      case element do
-        {:variable, variable} ->
-          value = variable |> String.to_atom() |> Macro.var(__MODULE__)
-          Map.put(acc, variable, value)
-        _ ->
-          acc
-      end
-    end)
+    entries =
+      Enum.reduce(path, [], fn element, acc ->
+        case element do
+          {:variable, variable} ->
+            value = variable |> String.to_atom() |> Macro.var(__MODULE__)
+            [{variable, value} | acc]
+          _ ->
+            acc
+        end
+      end)
+
+    {:%{}, [], entries}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -16,6 +16,7 @@ defmodule Maverick.MixProject do
       source_url: @repo,
       package: package(),
       start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       docs: docs()
     ]
@@ -34,6 +35,9 @@ defmodule Maverick.MixProject do
       {:nimble_parsec, "~> 1.1", optional: true}
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   defp package do
     %{

--- a/test/support/test_api.ex
+++ b/test/support/test_api.ex
@@ -1,0 +1,3 @@
+defmodule Maverick.Example do
+  use Maverick.Api, otp_app: :maverick
+end

--- a/test/support/test_route.ex
+++ b/test/support/test_route.ex
@@ -1,0 +1,15 @@
+defmodule Maverick.Test1 do
+  use Maverick, scope: "/api/v1"
+
+  @route path: "multiply", args: :required_params, error: 403
+  def multiply(num1, num2), do: num1 * num2
+
+  @route path: "hello/:name", method: :get
+  def hello(name), do: name
+
+  @route path: "fly/to/the/moon", args: :request
+  def foobar(num1), do: num1 * 3
+
+  @route path: "boobah/:id/clock", method: :put
+  def barbaz(), do: :name
+end


### PR DESCRIPTION
Constructs the map of path_param variables coming from the web route to be merged into the `%Maverick.Request{}` as part of the overall params available to backend functions.

Adds `test/support` infrastructure for beginning to integration test the `API` at runtime.