### PR TITLE
Cleans up the tests for route generation

### DIFF
--- a/lib/maverick.ex
+++ b/lib/maverick.ex
@@ -13,13 +13,13 @@ defmodule Maverick do
     end
   end
 
-  def __on_definition__(%Macro.Env{module: module}, :def, name, args, _guards, _body) do
+  def __on_definition__(%Macro.Env{module: module}, :def, name, _args, _guards, _body) do
     route_info = Module.get_attribute(module, :route) || :no_route
 
     unless route_info == :no_route do
       scope = Module.get_attribute(module, :maverick_route_scope)
       path = Keyword.fetch!(route_info, :path)
-      arg_type = Keyword.get(route_info, :args, :params)
+      arg_type = Keyword.get(route_info, :args, :params) |> validate_arg_type()
       success_code = Keyword.get(route_info, :success, 200) |> parse_http_code()
       error_code = Keyword.get(route_info, :error, 404) |> parse_http_code()
 
@@ -36,7 +36,6 @@ defmodule Maverick do
       Module.put_attribute(module, :maverick_routes, %{
         module: module,
         function: name,
-        arity: length(args),
         args: arg_type,
         method: method,
         path: path,
@@ -83,4 +82,10 @@ defmodule Maverick do
 
   defp ensure_leading_slash("/" <> _rest = string), do: string
   defp ensure_leading_slash(path), do: "/" <> path
+
+  defp validate_arg_type({:required_params, list}),
+    do: {:required_params, Enum.map(list, &to_string/1)}
+
+  defp validate_arg_type(:params), do: :params
+  defp validate_arg_type(:request), do: :request
 end

--- a/lib/maverick.ex
+++ b/lib/maverick.ex
@@ -30,8 +30,8 @@ defmodule Maverick do
         |> String.upcase()
 
       {:ok, path, "", %{}, _, _} =
-        ensure_leading_slash(scope) <> ensure_leading_slash(path)
-        |> Maverick.PathParser.parse
+        (ensure_leading_slash(scope) <> ensure_leading_slash(path))
+        |> Maverick.PathParser.parse()
 
       Module.put_attribute(module, :maverick_routes, %{
         module: module,

--- a/lib/maverick/api/initializer.ex
+++ b/lib/maverick/api/initializer.ex
@@ -91,6 +91,7 @@ defmodule Maverick.Api.Initializer do
           variable
           |> String.to_atom()
           |> Macro.var(__MODULE__)
+
         _ ->
           element
       end
@@ -104,6 +105,7 @@ defmodule Maverick.Api.Initializer do
           {:variable, variable} ->
             value = variable |> String.to_atom() |> Macro.var(__MODULE__)
             [{variable, value} | acc]
+
           _ ->
             acc
         end

--- a/test/maverick/path_parser_test.exs
+++ b/test/maverick/path_parser_test.exs
@@ -35,9 +35,9 @@ defmodule Maverick.PathParserTest do
 
   test "errors on invalid characters" do
     assert {:error, "expected only legal characters", _, %{}, _, _} =
-      Maverick.PathParser.parse("/api/v?/foo")
+             Maverick.PathParser.parse("/api/v?/foo")
 
     assert {:error, "expected only legal characters", _, %{}, _, _} =
-      Maverick.PathParser.parse("/users/:user-id")
+             Maverick.PathParser.parse("/users/:user-id")
   end
 end

--- a/test/maverick_test.exs
+++ b/test/maverick_test.exs
@@ -1,57 +1,55 @@
 defmodule MaverickTest do
   use ExUnit.Case
 
-  defmodule Example do
-    use Maverick, scope: "/api/v1"
-
-    @route path: "multiply", args: :required_params, error: 403
-    def multiply(num1, num2), do: double(num1 * num2)
-
-    @route path: "wrong"
-    defp double(num), do: num * 2
-
-    def interpolate(arg), do: "The cat sat on the #{arg}"
-
-    @route path: "hello/:name", method: :get
-    def hello(name), do: name
-
-    defmacro upcase(string) do
-      quote do
-        String.upcase(unquote(string))
-      end
-    end
-  end
-
   test "creates getters for annotated public functions" do
     assert %{
-             module: MaverickTest.Example,
+             module: Maverick.TestRoute1,
              function: :multiply,
-             arity: 2,
              method: "POST",
              path: ["api", "v1", "multiply"],
-             args: :required_params,
+             args: {:required_params, ["num1", "num2"]},
              error_code: 403,
              success_code: 200
-           } in Example.Maverick.Router.routes()
+           } in Maverick.TestRoute1.Maverick.Router.routes()
 
     assert %{
-             module: MaverickTest.Example,
+             module: Maverick.TestRoute1,
              function: :hello,
-             arity: 1,
              method: "GET",
              path: ["api", "v1", "hello", {:variable, "name"}],
              args: :params,
              error_code: 404,
              success_code: 200
-           } in Example.Maverick.Router.routes()
+           } in Maverick.TestRoute1.Maverick.Router.routes()
+
+    assert %{
+             module: Maverick.TestRoute2,
+             function: :come_fly_with_me,
+             method: "POST",
+             path: ["api", "v1", "fly", "me", "to", "the"],
+             args: :request,
+             error_code: 404,
+             success_code: 200
+           } in Maverick.TestRoute2.Maverick.Router.routes()
+
+    assert %{
+             module: Maverick.TestRoute2,
+             function: :current_time,
+             method: "PUT",
+             path: ["api", "v1", "clock", {:variable, "timezone"}],
+             args: :params,
+             error_code: 404,
+             success_code: 200
+           } in Maverick.TestRoute2.Maverick.Router.routes()
   end
 
   test "ignores invalid or unannotated functions" do
-    route_functions = Example.Maverick.Router.routes()
+    route1_functions = Maverick.TestRoute1.Maverick.Router.routes()
+    route2_functions = Maverick.TestRoute2.Maverick.Router.routes()
 
-    refute function_member(route_functions, :double)
-    refute function_member(route_functions, :interpolate)
-    refute function_member(route_functions, :upcase)
+    refute function_member(route1_functions, :double)
+    refute function_member(route1_functions, :interpolate)
+    refute function_member(route2_functions, :upcase)
   end
 
   defp function_member(routes, function) do

--- a/test/support/test_api.ex
+++ b/test/support/test_api.ex
@@ -1,3 +1,3 @@
-defmodule Maverick.Example do
+defmodule Maverick.TestApi do
   use Maverick.Api, otp_app: :maverick
 end

--- a/test/support/test_route.ex
+++ b/test/support/test_route.ex
@@ -1,15 +1,23 @@
 defmodule Maverick.Test1 do
   use Maverick, scope: "/api/v1"
 
-  @route path: "multiply", args: :required_params, error: 403
-  def multiply(num1, num2), do: num1 * num2
+  @route path: "multiply", args: [required_params: [:num1, :num2]], error: 403
+  def multiply(%{"num1" => num1, "num2" => num2}), do: %{product: num1 * num2}
 
   @route path: "hello/:name", method: :get
-  def hello(name), do: name
+  def hello(%{"name" => name}), do: "Hi there " <> name
 
-  @route path: "fly/to/the/moon", args: :request
-  def foobar(num1), do: num1 * 3
+  @route path: "fly/me/to/the", args: :request
+  def come_fly_with_me(req) do
+    destination = Enum.random(["moon", "mars", "stars"])
 
-  @route path: "boobah/:id/clock", method: :put
-  def barbaz(), do: :name
+    response_header = Map.get(req.headers, "Customer-Name", "Anonymous")
+
+    {:ok, response_header, %{"destination" => destination}}
+  end
+
+  @route path: "clock/:timezone", method: :put
+  def current_time(%{"timezone" => timezone}) do
+    DateTime.now(timezone)
+  end
 end

--- a/test/support/test_routes.ex
+++ b/test/support/test_routes.ex
@@ -1,11 +1,24 @@
-defmodule Maverick.Test1 do
+defmodule Maverick.TestRoute1 do
   use Maverick, scope: "/api/v1"
 
-  @route path: "multiply", args: [required_params: [:num1, :num2]], error: 403
+  @route path: "multiply", args: {:required_params, [:num1, :num2]}, error: 403
   def multiply(%{"num1" => num1, "num2" => num2}), do: %{product: num1 * num2}
+
+  @route path: "wrong"
+  defp double(%{"num" => num}), do: num * 2
+
+  def interpolate(arg) do
+    double(%{"num" => 2})
+
+    "The cat sat on the #{arg}"
+  end
 
   @route path: "hello/:name", method: :get
   def hello(%{"name" => name}), do: "Hi there " <> name
+end
+
+defmodule Maverick.TestRoute2 do
+  use Maverick, scope: "/api/v1"
 
   @route path: "fly/me/to/the", args: :request
   def come_fly_with_me(req) do
@@ -19,5 +32,11 @@ defmodule Maverick.Test1 do
   @route path: "clock/:timezone", method: :put
   def current_time(%{"timezone" => timezone}) do
     DateTime.now(timezone)
+  end
+
+  defmacro upcase(string) do
+    quote do
+      String.upcase(unquote(string))
+    end
   end
 end


### PR DESCRIPTION
Cleans up test case scenario, moving all of the test implementations of the route-implementing function modules and the API implementation module exclusively into the "test/support" directory.

Makes the test route functions more "realistic" to prepare for the different arg-type handling in the next PR.