### PR TITLE
Error Responses automatically return object

### DIFF
--- a/lib/maverick/api/initializer.ex
+++ b/lib/maverick/api/initializer.ex
@@ -67,9 +67,10 @@ defmodule Maverick.Api.Initializer do
 
         def handle(method, path, req) do
           Logger.info(fn -> "Unhandled request received : #{inspect(req)}" end)
-          error_code = 404
-          error_response = %{error_code: error_code, error_message: "Not Found"}
-          {error_code, [Maverick.Request.Util.content_type()], Jason.encode!(error_response)}
+          error_response = %{error_code: 404, error_message: "Not Found"}
+
+          {error_response.error_code, [Maverick.Request.Util.content_type()],
+           Jason.encode!(error_response)}
         end
 
         @impl true

--- a/lib/maverick/api/initializer.ex
+++ b/lib/maverick/api/initializer.ex
@@ -67,7 +67,9 @@ defmodule Maverick.Api.Initializer do
 
         def handle(method, path, req) do
           Logger.info(fn -> "Unhandled request received : #{inspect(req)}" end)
-          {404, [Maverick.Request.Util.content_type()], Jason.encode!("Not Found")}
+          error_code = 404
+          error_response = %{error_code: error_code, error_message: "Not Found"}
+          {error_code, [Maverick.Request.Util.content_type()], Jason.encode!(error_response)}
         end
 
         @impl true

--- a/lib/mix/tasks/mvk.routes.ex
+++ b/lib/mix/tasks/mvk.routes.ex
@@ -82,11 +82,7 @@ defmodule Mix.Tasks.Mvk.Routes do
     %{args: args, function: func, method: method, module: mod, path: path} = route
     {method_len, path_len, mod_len, func_len} = column_widths
 
-<<<<<<< HEAD
     String.pad_leading(method, method_len) <>
-=======
-      String.pad_leading(method, method_len) <>
->>>>>>> e3d1619... Make route list public on Api module, mix task
       "  " <>
       String.pad_trailing(path, path_len) <>
       "  " <>

--- a/lib/mix/tasks/mvk.routes.ex
+++ b/lib/mix/tasks/mvk.routes.ex
@@ -82,7 +82,11 @@ defmodule Mix.Tasks.Mvk.Routes do
     %{args: args, function: func, method: method, module: mod, path: path} = route
     {method_len, path_len, mod_len, func_len} = column_widths
 
+<<<<<<< HEAD
     String.pad_leading(method, method_len) <>
+=======
+      String.pad_leading(method, method_len) <>
+>>>>>>> e3d1619... Make route list public on Api module, mix task
       "  " <>
       String.pad_trailing(path, path_len) <>
       "  " <>

--- a/test/maverick/api_test.exs
+++ b/test/maverick/api_test.exs
@@ -71,7 +71,7 @@ defmodule Maverick.ApiTest do
 
       assert 404 == resp_code(resp)
       assert resp_content_type(resp)
-      assert "Not Found" == resp_body(resp)
+      assert %{"error_code" => 404, "error_message" => "Not Found"} == resp_body(resp)
     end
 
     test "handles error tuples from internal functions" do


### PR DESCRIPTION
Previous error responses returned a content-type of application/json while the default implementation of the exception handler returns an object.

This change refactors the error behavior to also return an object.